### PR TITLE
[ZP-9] Add support for variables in JDBCInterpreter statementPrecode.

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -718,7 +718,11 @@ public class JDBCInterpreter extends KerberosInterpreter {
               getProperty(String.format(STATEMENT_PRECODE_KEY_TEMPLATE, propertyKey));
           
           if (StringUtils.isNotBlank(statementPrecode)) {
-            statement.execute(statementPrecode);
+            String noteId = interpreterContext.getNoteId();
+            String contextStatementPrecode = statementPrecode
+                .replace("#{noteId}", noteId != null ? noteId : "")
+                .replace("#{user}", user);
+            statement.execute(contextStatementPrecode);
           }
 
           boolean isResultSetAvailable = statement.execute(sqlToExecute);


### PR DESCRIPTION
### What is this PR for?
Variables `#{noteId}` and `#{user}` replaced to actual values.
Cherry picked from commits 9039f16954e0fb9f0e81ad9de13df5a6c988e932, 4b90e8700be572279c7aa32d5e374395d5e8cd37.

### What type of PR is it?
Feature

### Todos

### What is the Jira issue?
ZP-9

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? yes
