### PR TITLE
[ZP-18] Add port for remote debug to all JVMs at start

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -16,6 +16,14 @@
 # limitations under the License.
 #
 
+if [[ -z "${ZEPPELIN_REMOTE_DEBUG_INITIALISED}" ]]; then
+  export ZEPPELIN_REMOTE_DEBUG_INITIALISED="true"
+  ZEPPELIN_JAVA_PORT=$(python -c 'import socket;s=socket.socket();s.bind(("", 0));print(s.getsockname()[1]);s.close()')
+  export ZEPPELIN_JAVA_OPTS="${ZEPPELIN_JAVA_OPTS} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${ZEPPELIN_JAVA_PORT}"
+  ZEPPELIN_INTP_JAVA_PORT=$(python -c 'import socket;s=socket.socket();s.bind(("", 0));print(s.getsockname()[1]);s.close()')
+  export ZEPPELIN_INTP_JAVA_OPTS="${ZEPPELIN_INTP_JAVA_OPTS} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${ZEPPELIN_INTP_JAVA_PORT}"
+fi
+
 if [ -L ${BASH_SOURCE-$0} ]; then
   FWDIR=$(dirname $(readlink "${BASH_SOURCE-$0}"))
 else


### PR DESCRIPTION
### What is this PR for?
Added port for remote debug all JVMs at start.
Cherry picked from 60e39cb53ddaa88e23c184e92ec76f75324d64ba

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
ZP-18

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
