### PR TITLE
[ZP-21] Add job status check in ManagedInterpreterGroup#close

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
@@ -122,6 +122,14 @@ public class ManagedInterpreterGroup extends InterpreterGroup {
     for (Interpreter interpreter : interpreters) {
       Scheduler scheduler = interpreter.getScheduler();
       for (Job job : scheduler.getAllJobs()) {
+        if (job.getStatus().isCompleted()) {
+          LOGGER.error(
+                  "Tried to abort job {}, but job status is {}",
+                  job.getJobName(),
+                  job.getStatus().toString()
+          );
+          continue;
+        }
         job.abort();
         job.setStatus(Job.Status.ABORT);
         LOGGER.info("Job " + job.getJobName() + " aborted ");


### PR DESCRIPTION
### What is this PR for?
If bug described in [ZEPPELIN-3704](https://issues.apache.org/jira/browse/ZEPPELIN-3704) wasn't fixed after refactoring `Scheduler` in 0.9.0 we should see additional error logs, otherwise this additions could be removed. 

### What type of PR is it?
Bug Fix

### What is the Jira issue?
ZP-21

### How should this be tested?
* Check logs for some time

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
