### PR TITLE
[ZP-26] - Remove event if dom's element destroy

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -103,6 +103,27 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     connectedOnce = true;
   });
 
+  $scope.addEvent = function(config) {
+    let removeEventByID = function(id) {
+      let events = jQuery._data(config.element, 'events')[config.eventType];
+      if (!events) {
+        return;
+      }
+      for (let i=0; i < events.length; i++) {
+        if (events[i].data && events[i].data.eventID === id) {
+          events.splice(i, 1);
+          i--;
+        }
+      }
+    };
+
+    removeEventByID(config.eventID);
+    angular.element(config.element).bind(config.eventType, {eventID: config.eventID}, config.handler);
+    angular.element(config.onDestroyElement).scope().$on('$destroy', () => {
+      removeEventByID(config.eventID);
+    });
+  };
+
   $scope.getCronOptionNameFromValue = function(value) {
     if (!value) {
       return '';
@@ -1564,8 +1585,15 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     document.removeEventListener('keydown', $scope.keyboardShortcut);
   });
 
-  angular.element(window).bind('resize', function() {
-    const actionbarHeight = document.getElementById('actionbar').lastElementChild.clientHeight;
-    angular.element(document.getElementById('content')).css('padding-top', actionbarHeight - 20);
+  let content = document.getElementById('content');
+  $scope.addEvent({
+    eventID: content.id,
+    eventType: 'resize',
+    element: window,
+    onDestroyElement: content,
+    handler: () => {
+      const actionbarHeight = document.getElementById('actionbar').lastElementChild.clientHeight;
+      angular.element(document.getElementById('content')).css('padding-top', actionbarHeight - 20);
+    },
   });
 }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -755,9 +755,10 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       }
 
       autoAdjustEditorHeight(_editor);
-      angular.element(window).resize(function() {
-        autoAdjustEditorHeight(_editor);
-      });
+
+      let adjustEditorListener = () => autoAdjustEditorHeight(_editor);
+      angular.element(window).resize(adjustEditorListener);
+      $scope.$on('$destroy', () => angular.element(window).unbind('resize', adjustEditorListener));
 
       if (navigator.appVersion.indexOf('Mac') !== -1) {
         $scope.editor.setKeyboardHandler('ace/keyboard/emacs');

--- a/zeppelin-web/src/app/notebook/paragraph/resizable.directive.js
+++ b/zeppelin-web/src/app/notebook/paragraph/resizable.directive.js
@@ -24,6 +24,23 @@ function ResizableDirective() {
     },
   };
 
+  let addEvent = function(config) {
+    let removeEventByID = function(id) {
+      let events = jQuery._data(config.element, 'events')[config.eventType];
+      for (let i=0; i < events.length; i++) {
+        if (events[i].data && events[i].data.eventID === id) {
+          events.splice(i, 1);
+          i--;
+        }
+      }
+    };
+    removeEventByID(config.eventID);
+    angular.element(config.element).bind(config.eventType, {eventID: config.eventID}, config.handler);
+    angular.element(config.onDestroyElement).scope().$on('$destroy', () => {
+      removeEventByID(config.eventID);
+    });
+  };
+
   return {
     restrict: 'A',
     scope: {
@@ -59,8 +76,13 @@ function ResizableDirective() {
         resize = JSON.parse(resize);
         if (resize.allowresize === 'true') {
           resetResize(elem, resize);
-          angular.element(window).resize(function() {
-            resetResize(elem, resize);
+
+          addEvent({
+            eventID: elem[0].id,
+            eventType: 'resize',
+            element: window,
+            onDestroyElement: elem[0],
+            handler: () => resetResize(elem, resize),
           });
         }
       });

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -683,8 +683,18 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
           builtInViz.instance.render(transformed);
           builtInViz.instance.renderSetting(visualizationSettingTargetEl);
           builtInViz.instance.activate();
-          angular.element(window).resize(() => {
-            builtInViz.instance.resize();
+
+          let eventID = builtInViz.instance.targetEl.id;
+          if (!eventID) {
+            eventID = builtInViz.instance.targetEl[0].id;
+          }
+
+          $scope.addEvent({
+            eventID: eventID,
+            eventType: 'resize',
+            element: window,
+            onDestroyElement: builtInViz.instance.targetEl,
+            handler: () => builtInViz.instance.resize(),
           });
         } catch (err) {
           console.error('Graph drawing error %o', err);


### PR DESCRIPTION
# Description
This PR change logic of add new event listener on frontend. Now then add new event listener, also added destroy listener. Destroy listener attach to some DOM element and then this element destroyed listener drop event listener.
Since the old listeners were not deleted when changing the size of the paragraph / window, an error occurred. Because of this error, updating the text in the paragraph did not happen until the end.

## Info
#### PR type: `Bug Fix` |  Jira issue: [`ZEPPELIN-3616`](https://issues.apache.org/jira/browse/ZEPPELIN-3616), ZP-23, ZP-26

## Screenshots
### List of all resize event (after some time of work)
<p align="center">before (77 lis.)</p>

![before](https://user-images.githubusercontent.com/30798933/43723409-421e44a0-99a0-11e8-8945-5d52e275ed02.png)

<p align="center">after (16 lis.)</p>

![after](https://user-images.githubusercontent.com/30798933/43723425-4ce02a3e-99a0-11e8-96ee-59ac177945d4.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no