### PR TITLE
[ZP-19] [ZEPPELIN-3511] remove old button "Download Data as CSV/TSV"

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
@@ -73,26 +73,6 @@ limitations under the License.
   </ul>
 </div>
 
-<div class="btn-group"
-     ng-if="(type == 'TABLE' || type == 'NETWORK') && !asIframe && !viewOnly"
-     style="margin-bottom: 10px;">
-  <button type="button" class="btn btn-default btn-sm"
-          style="margin-left:10px"
-          ng-click="exportToDSV(',')"
-          uib-tooltip="Download Data as CSV" tooltip-placement="bottom">
-    <i class="fa fa-download"></i>
-  </button>
-  <button type="button" class="btn btn-default btn-sm dropdown-toggle caretBtn"
-          data-toggle="dropdown">
-    <span class="caret" style="margin: 0px;"></span>
-    <span class="sr-only">Toggle Dropdown</span>
-  </button>
-  <ul class="dropdown-menu" role="menu" style="min-width: 70px;">
-    <li ng-click="exportToDSV(',')"><a>CSV</a></li>
-    <li ng-click="exportToDSV('\t')"><a>TSV</a></li>
-  </ul>
-</div>
-
 <span
    ng-if="(type == 'TABLE' || type == 'NETWORK') && !config.helium.activeApp && !asIframe && !viewOnly"
    style="margin-left:10px; cursor:pointer; display: inline-block; vertical-align:top; position: relative; line-height:30px;">

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -12,8 +12,6 @@
  * limitations under the License.
  */
 
-import moment from 'moment';
-
 import DatasetFactory from '../../../tabledata/datasetfactory';
 import TableVisualization from '../../../visualization/builtins/visualization-table';
 import BarchartVisualization from '../../../visualization/builtins/visualization-barchart';
@@ -33,7 +31,7 @@ angular.module('zeppelinWebApp').controller('ResultCtrl', ResultCtrl);
 
 function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location,
                     $timeout, $compile, $http, $q, $templateCache, $templateRequest, $sce, websocketMsgSrv,
-                    baseUrlSrv, ngToast, saveAsService, noteVarShareService, heliumService,
+                    baseUrlSrv, ngToast, noteVarShareService, heliumService,
                     uiGridConstants) {
   'ngInject';
 
@@ -856,43 +854,6 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
     paragraph.config.colWidth = width;
 
     commitParagraphResult(paragraph.title, paragraph.text, newConfig, newParams);
-  };
-
-  $scope.exportToDSV = function(delimiter) {
-    let dsv = '';
-    let dateFinished = moment(paragraph.dateFinished).format('YYYY-MM-DD hh:mm:ss A');
-    let exportedFileName = paragraph.title ? paragraph.title + '_' + dateFinished : 'data_' + dateFinished;
-
-    for (let titleIndex in tableData.columns) {
-      if (tableData.columns.hasOwnProperty(titleIndex)) {
-        dsv += tableData.columns[titleIndex].name + delimiter;
-      }
-    }
-    dsv = dsv.substring(0, dsv.length - 1) + '\n';
-    for (let r in tableData.rows) {
-      if (tableData.rows.hasOwnProperty(r)) {
-        let row = tableData.rows[r];
-        let dsvRow = '';
-        for (let index in row) {
-          if (row.hasOwnProperty(index)) {
-            let stringValue = (row[index]).toString();
-            if (stringValue.indexOf(delimiter) > -1) {
-              dsvRow += '"' + stringValue + '"' + delimiter;
-            } else {
-              dsvRow += row[index] + delimiter;
-            }
-          }
-        }
-        dsv += dsvRow.substring(0, dsvRow.length - 1) + '\n';
-      }
-    }
-    let extension = '';
-    if (delimiter === '\t') {
-      extension = 'tsv';
-    } else if (delimiter === ',') {
-      extension = 'csv';
-    }
-    saveAsService.saveAs(dsv, exportedFileName, extension);
   };
 
   $scope.getBase64ImageSrc = function(base64Data) {


### PR DESCRIPTION
### What is this PR for?
This PR removes the legacy method (button and dropdown near the top left of each paragraph) for exporting the displayed data as a CSV or TSV file. The widgets of the legacy method are seen in the images below.

![](https://user-images.githubusercontent.com/477015/41198653-71eb5646-6ca0-11e8-9e05-988d6b9a58e5.png)
![](https://user-images.githubusercontent.com/477015/41198654-7223e7d6-6ca0-11e8-8f4d-73f4c8e9234a.png)

The legacy method is now redundant as a new improved data-export menu is available (top right corner of data display grid). The new method also does not suffer from certain issues in the legacy method. The new method is seen in the image below.


![](https://user-images.githubusercontent.com/477015/41198662-c527c7ea-6ca0-11e8-9a29-e17b92392d5c.png)


### What type of PR is it?
[Improvement]

### What is the Jira issue?
ZP-19
https://issues.apache.org/jira/browse/ZEPPELIN-3511
https://github.com/apache/zeppelin/pull/3013

### How should this be tested?
1. Travis CI pass
2. Manual checking (see screenshot below)

### Screenshots (if appropriate)
![](https://user-images.githubusercontent.com/477015/41198641-47f2777a-6ca0-11e8-8289-dbc0978468ec.png)

### Questions:
* Does the licenses files need update? - No
* Is there breaking changes for older versions? - No
* Does this needs documentation? - No
