### PR TITLE
[ZP-62] [ZEPPELIN-3814] Add apply button to table settings

### DIFF
--- a/zeppelin-web/src/app/visualization/builtins/visualization-table-setting.html
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table-setting.html
@@ -18,13 +18,13 @@ limitations under the License.
     <span style="float: right;">
        <div class="btn-group" role="group" aria-label="...">
          <div type="button" ng-click="applyTableOption()"
-                       uib-tooltip="Apply new setting" tooltip-placement="left"
+                       uib-tooltip="Apply new setting" tooltip-placement="top"
                        class="btn btn-default" style="font-size: 11px; padding: 2px 5px 2px 5px;">
-           <i class="fa fa-check-square" aria-hidden="true"></i>
+           <i class="fa fa-floppy-o" aria-hidden="true"></i>
          </div>
 
          <div type="button" ng-click="resetTableOption()"
-              uib-tooltip="Restore the default setting" tooltip-placement="left"
+              uib-tooltip="Restore the default setting" tooltip-placement="top"
               class="btn btn-default" style="font-size: 11px; padding: 2px 5px 2px 5px;">
            <i class="fa fa-undo" aria-hidden="true"></i>
          </div>

--- a/zeppelin-web/src/app/visualization/builtins/visualization-table-setting.html
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table-setting.html
@@ -17,6 +17,12 @@ limitations under the License.
     <span style="vertical-align: middle; display: inline-block; margin-top: 3px;">Table Options</span>
     <span style="float: right;">
        <div class="btn-group" role="group" aria-label="...">
+         <div type="button" ng-click="applyTableOption()"
+                       uib-tooltip="Apply new setting" tooltip-placement="left"
+                       class="btn btn-default" style="font-size: 11px; padding: 2px 5px 2px 5px;">
+           <i class="fa fa-check-square" aria-hidden="true"></i>
+         </div>
+
          <div type="button" ng-click="resetTableOption()"
               uib-tooltip="Restore the default setting" tooltip-placement="left"
               class="btn btn-default" style="font-size: 11px; padding: 2px 5px 2px 5px;">

--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -66,6 +66,7 @@ export default class TableVisualization extends Visualization {
     this.passthrough = new PassthroughTransformation(config);
     this.emitTimeout = null;
     this.isRestoring = false;
+    this.isUpdated = false;
 
     initializeTableConfig(config, TABLE_OPTION_SPECS);
   }
@@ -382,7 +383,12 @@ export default class TableVisualization extends Visualization {
       // gridApi.selection.on.rowSelectionChangedBatch(scope, () => { self.persistConfigWithGridState(self.config) })
     };
 
-    if (!gridElem) {
+    if (!gridElem || this.isUpdated) {
+      if (this.isUpdated) {
+        this.targetEl.find(gridElem).off();
+        this.targetEl.find(gridElem).detach();
+        this.isUpdated = false;
+      }
       // create, compile and append grid elem
       gridElem = angular.element(
         `<div id="${gridElemId}" ui-grid="${gridElemId}"
@@ -510,6 +516,12 @@ export default class TableVisualization extends Visualization {
           resetTableOptionConfig(configObj);
           initializeTableConfig(configObj, TABLE_OPTION_SPECS);
           self.persistConfigWithGridState(configObj);
+        },
+        applyTableOption: () => {
+          this.isUpdated = true;
+          // emit config to re-render table
+          configObj.initialized = true;
+          self.persistConfig(configObj);
         },
         tableWidgetOnKeyDown: (event, optSpec) => {
           const code = event.keyCode || event.which;


### PR DESCRIPTION
### What is this PR for?
Now changes in table settings applies only after page refreshing which isn't convenient
* Settings menu before PR:
![screenshot-1](https://user-images.githubusercontent.com/6136993/47079792-f49b6580-d20e-11e8-837e-98ba5443f3b3.png)
* Menu with new button:
![3814](https://user-images.githubusercontent.com/6136993/51320121-ecea9780-1a6f-11e9-850f-fcaf061ff5f3.gif)

### What type of PR is it?
Improvement

### What is the Jira issue?
* ZP-62
* [ZEPPELIN-3814](https://issues.apache.org/jira/browse/ZEPPELIN-3814)
* https://github.com/apache/zeppelin/pull/3205

### How should this be tested?
* CI pass
* Manually tested

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
