### PR TITLE
[ZP-91] Add info about running interpreters to API and JMX 

### DIFF
--- a/docs/usage/rest_api/interpreter.md
+++ b/docs/usage/rest_api/interpreter.md
@@ -507,6 +507,130 @@ The role of registered interpreters, settings and interpreters group are describ
   </table>
 
 <br/>
+### List of running interpreters
+
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method returns all the running interpreters available on the server.</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/interpreter/running```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td>Sample JSON response</td>
+      <td>
+        <pre>
+{
+  "status": "OK",
+  "message": "",
+  "body": [
+   {
+     "port": "37395",
+     "name": "python-shared_process",
+     "host": "192.168.88.13",
+     "group": "python"
+   },
+   {
+     "port": "45105",
+     "name": "spark-shared_process",
+     "host":"192.168.88.13",
+     "group":"spark"
+   },
+   {
+     "port": "41281",
+     "name":"sh-shared_process",
+     "host":"192.168.88.13",
+     "group":"sh"
+   },
+   { "port": "40873",
+     "name": "md-shared_process",
+     "host": "192.168.88.13",
+     "group":"md"
+   }
+  ]
+}
+        </pre>
+      </td>
+    </tr>
+  </table>
+
+<br/>
+###  Get paragraph info of running interpreters
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method lists the running paragraphs grouped by interpreters.
+          The body field of the returned JSON contain information about paragraphs.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/interpreter/running/jobs```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response (python is configured with isolated per Note setting) </td>
+      <td><pre>
+{
+  "status": "OK",
+  "message": "",
+  "body": {
+    "lastResponseUnixTime": 1544653922027,
+    "runningInterpreters": {
+      "python--2DX6CWH35": {
+        "port": "37799",
+        "host": "192.168.88.13",
+        "paragraphs": [
+          {
+            "interpreterText": "python",
+            "noteName": "Processes",
+            "noteId": "2DX6CWH35",
+            "id": "paragraph_1544653814070_1471435369",
+            "user": "anonymous"
+          }
+        ],
+        "group": "python"
+      },
+      "sh-shared_process": {
+        "port": "33857",
+        "host": "192.168.88.13",
+        "paragraphs": [
+          {
+            "interpreterText": "sh",
+            "noteName": "Processes",
+            "noteId": "2DX6CWH35",
+            "id": "paragraph_1544653826296_1659478713",
+            "user":"anonymous"
+          }
+        ],
+        "group":"sh"
+      }
+    }
+   }
+}</pre></td>
+    </tr>
+  </table>
+
+<br/>
 ### Add a new repository for dependency resolving
 
   <table class="table-configuration">

--- a/docs/usage/rest_api/interpreter.md
+++ b/docs/usage/rest_api/interpreter.md
@@ -595,37 +595,42 @@ The role of registered interpreters, settings and interpreters group are describ
   "message": "",
   "body": {
     "lastResponseUnixTime": 1544653922027,
-    "runningInterpreters": {
-      "python--2DX6CWH35": {
-        "port": "37799",
-        "host": "192.168.88.13",
-        "paragraphs": [
-          {
-            "interpreterText": "python",
-            "noteName": "Processes",
-            "noteId": "2DX6CWH35",
-            "id": "paragraph_1544653814070_1471435369",
-            "user": "anonymous"
-          }
-        ],
-        "group": "python"
+    "runningInterpreters": [
+      {
+        "name": "python--2DX6CWH35",
+        "group": "python",
+        "host": "172.30.13.213",
+        "port": "33757",
+        "interpreterText": "python",
+        "noteName": "Processes",
+        "noteId": "2DX6CWH35",
+        "id": "paragraph_1544653814070_1471435369",
+        "user": "anonymous"
       },
-      "sh-shared_process": {
-        "port": "33857",
-        "host": "192.168.88.13",
-        "paragraphs": [
-          {
-            "interpreterText": "sh",
-            "noteName": "Processes",
-            "noteId": "2DX6CWH35",
-            "id": "paragraph_1544653826296_1659478713",
-            "user":"anonymous"
-          }
-        ],
-        "group":"sh"
+      {
+        "name": "spark-shared_process",
+        "group": "spark",
+        "host": "172.30.13.213",
+        "port": "42861",
+        "interpreterText": "spark.pyspark",
+        "noteName": "Processes",
+        "noteId": "2DX6CWH35",
+        "id": "paragraph_1544653819987_-1635354679",
+        "user":"anonymous"
+      },
+      {
+        "name": "sh-shared_process",
+        "group": "sh",
+        "host": "172.30.13.213",
+        "port": "38089",
+        "interpreterText": "sh",
+        "noteName": "Processes",
+        "noteId": "2DX6CWH35",
+        "id": "paragraph_1544653826296_1659478713",
+        "user":"anonymous"
       }
-    }
-   }
+    ]
+  }
 }</pre></td>
     </tr>
   </table>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -18,6 +18,7 @@
 package org.apache.zeppelin.rest;
 
 import com.google.common.collect.Maps;
+import java.util.HashMap;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -333,5 +334,35 @@ public class InterpreterRestApi {
     }
 
     return new JsonResponse<>(Status.OK).build();
+  }
+
+  /**
+   * Get all running interpreters.
+   */
+  @GET
+  @Path("running")
+  @ZeppelinApi
+  public Response listRunningInterpreters() {
+    return new JsonResponse<>(
+        Status.OK,
+        "",
+        interpreterSettingManager.getRunningInterpreters()
+    ).build();
+  }
+
+  /**
+   * Get info about the running paragraphs grouped by their interpreters.
+   *
+   * @return JSON with status.OK
+   */
+  @GET
+  @Path("running/jobs")
+  @ZeppelinApi
+  public Response getRunning() {
+    Map<String, Object> response = new HashMap<>();
+    response.put("lastResponseUnixTime", System.currentTimeMillis());
+    response.put("runningInterpreters", notebookServer.getRunningInterpretersParagraphInfo());
+
+    return new JsonResponse<>(Status.OK, "", response).build();
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -346,7 +346,7 @@ public class InterpreterRestApi {
     return new JsonResponse<>(
         Status.OK,
         "",
-        interpreterSettingManager.getRunningInterpreters()
+        interpreterSettingManager.getRunningInterpretersInfo()
     ).build();
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import java.util.Collection;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URISyntaxException;
@@ -49,10 +50,13 @@ import org.apache.zeppelin.display.Input;
 import org.apache.zeppelin.helium.ApplicationEventListener;
 import org.apache.zeppelin.helium.HeliumPackage;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
+import org.apache.zeppelin.interpreter.InterpreterNotFoundException;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterResultMessage;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
+import org.apache.zeppelin.interpreter.ManagedInterpreterGroup;
 import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
+import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcess;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.notebook.Note;
@@ -1864,6 +1868,87 @@ public class NotebookServer extends WebSocketServlet
   }
 
   @ManagedOperation
+  public List<Map<String, String>> getParagraphsInfo(String noteId) {
+    Note note = notebook().getNote(noteId);
+    return note.generateParagraphsInfo();
+  }
+
+  /**
+   * Extract running paragraphs info grouped by running interpreters.
+   */
+  @ManagedOperation
+  public Map<String, Object> getRunningInterpretersParagraphInfo() {
+    Map<String, Object> runningInterpretersWithParagraphInfo = new HashMap<>();
+    notebook().getAllNotes().stream()
+        .map(Note::getParagraphs)
+        .flatMap(Collection::stream)
+        .filter(Paragraph::isRunning)
+        .forEach(p -> addBindedInterpreterInfo(runningInterpretersWithParagraphInfo, p));
+    return runningInterpretersWithParagraphInfo;
+  }
+
+  /**
+   * Update running interpreter info with paragraph data.
+   */
+  private void addBindedInterpreterInfo(
+      Map<String, Object> runningInterpretersWithParagraphInfo, Paragraph paragraph) {
+    List<Map<String, String>> runningInterpreters = notebook()
+        .getInterpreterSettingManager()
+        .getRunningInterpreters();
+
+    for (Map<String, String> runningInterpreterInfo : runningInterpreters) {
+      RemoteInterpreterProcess process = null;
+      try {
+        process = ((ManagedInterpreterGroup) paragraph.getBindedInterpreter()
+            .getInterpreterGroup()).getInterpreterProcess();
+      } catch (InterpreterNotFoundException e) {
+        LOG.error("Failed to get binded interpreter to paragraph {}", paragraph, e);
+      }
+      if (process != null
+          && process.getPort() == Integer.valueOf(runningInterpreterInfo.get("port"))
+          && process.getHost().equals(runningInterpreterInfo.get("host"))) {
+
+        Map<String, Object> interpreterInfoBeforeUpdate =
+            (Map<String, Object>) runningInterpretersWithParagraphInfo
+                .get(runningInterpreterInfo.get("name"));
+        if (interpreterInfoBeforeUpdate == null) {
+          // create interpreter info
+          interpreterInfoBeforeUpdate = new HashMap<>();
+          interpreterInfoBeforeUpdate.put("group", runningInterpreterInfo.get("group"));
+          interpreterInfoBeforeUpdate.put("port", runningInterpreterInfo.get("port"));
+          interpreterInfoBeforeUpdate.put("host", runningInterpreterInfo.get("host"));
+
+          // set running interpreter paragraphs
+          List<Map<String, String>> paragraphsInfo = new ArrayList<>();
+          interpreterInfoBeforeUpdate.put("paragraphs", paragraphsInfo);
+        }
+        // update interpreter info
+        List<Map<String, String>> paragraphsInfoBeforeUpdate =
+            (List<Map<String, String>>) interpreterInfoBeforeUpdate.get("paragraphs");
+        addParagraphInfo(paragraphsInfoBeforeUpdate, paragraph);
+
+        runningInterpretersWithParagraphInfo
+            .put(runningInterpreterInfo.get("name"), interpreterInfoBeforeUpdate);
+      }
+    }
+  }
+
+  /**
+   * Add paragraph info to interpreter paragraph info list.
+   */
+  private void addParagraphInfo(List<Map<String, String>> paragraphsInfoBeforeUpdate,
+      Paragraph paragraph) {
+    Note parentNote = paragraph.getNote();
+    Map<String, String> newParagraphInfo = new HashMap<>();
+    newParagraphInfo.put("interpreterText", paragraph.getIntpText());
+    newParagraphInfo.put("noteName", parentNote.getName());
+    newParagraphInfo.put("noteId", parentNote.getId());
+    newParagraphInfo.put("id", paragraph.getId());
+    newParagraphInfo.put("user", paragraph.getUser());
+    paragraphsInfoBeforeUpdate.add(newParagraphInfo);
+  }
+
+  @Override
   public void sendMessage(String message) {
     Message m = new Message(OP.NOTICE);
     m.data.put("notice", message);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -17,12 +17,10 @@
 package org.apache.zeppelin.socket;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.stream.Collectors;
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -59,7 +57,6 @@ import org.apache.zeppelin.interpreter.InterpreterResultMessage;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.ManagedInterpreterGroup;
 import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
-import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcess;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.notebook.Note;
@@ -1872,54 +1869,47 @@ public class NotebookServer extends WebSocketServlet
 
   @ManagedOperation
   public List<Map<String, String>> getParagraphsInfo(String noteId) {
-    Note note = notebook().getNote(noteId);
+    Note note = getNotebook().getNote(noteId);
     return note.generateParagraphsInfo();
   }
 
   /**
-   * Extract running paragraphs info grouped by running interpreters.
+   * Extract info about running interpreters with additional paragraph info.
    */
   @ManagedOperation
   public List<Map<String, String>> getRunningInterpretersParagraphInfo() {
-    return notebook().getAllNotes().stream()
+    return getNotebook().getAllNotes().stream()
         .map(Note::getParagraphs)
         .flatMap(Collection::stream)
         .filter(Paragraph::isRunning)
-        .map(this::addBindedInterpreterInfo)
-        .flatMap(Collection::stream)
+        .map(this::extractParagraphInfo)
         .collect(Collectors.toList());
   }
 
   /**
-   * Update running interpreter info with paragraph data.
+   * Extract paragraph's interpreter info with paragraph data.
    */
-  private List<Map<String, String>> addBindedInterpreterInfo(Paragraph paragraph) {
+  private Map<String, String> extractParagraphInfo(Paragraph paragraph) {
     try {
-      final RemoteInterpreterProcess process = ((ManagedInterpreterGroup) paragraph
-          .getBindedInterpreter().getInterpreterGroup()).getInterpreterProcess();
-      return notebook().getInterpreterSettingManager().getRunningInterpretersInfo().stream()
-          // find interpreter with same port and host
-          .filter(interpreterInfo ->
-              Integer.valueOf(interpreterInfo.get("port")) == process.getPort()
-              && interpreterInfo.get("host").equals(process.getHost()))
-          .map(interpreterInfo -> ImmutableMap.<String, String>builder()
-              //add all info about interpreter
-              .putAll(interpreterInfo)
-              // add paragraph info
-              .put("interpreterText", paragraph.getIntpText())
-              .put("noteName", paragraph.getNote().getName())
-              .put("noteId", paragraph.getNote().getId())
-              .put("id", paragraph.getId())
-              .put("user", paragraph.getUser())
-              .build())
-          .collect(Collectors.toList());
+      final ManagedInterpreterGroup process = (ManagedInterpreterGroup) paragraph
+          .getBindedInterpreter().getInterpreterGroup();
+      // add all info about binded interpreter
+      HashMap<String, String> info = new HashMap<>(
+          getNotebook().getInterpreterSettingManager().extractProcessInfo(process));
+      // add paragraph info
+      info.put("interpreterText", paragraph.getIntpText());
+      info.put("noteName", paragraph.getNote().getName());
+      info.put("noteId", paragraph.getNote().getId());
+      info.put("id", paragraph.getId());
+      info.put("user", paragraph.getUser());
+      return info;
     } catch (InterpreterNotFoundException e) {
       LOG.error("Failed to get binded interpreter for paragraph {}", paragraph, e);
+      return new HashMap<>();
     }
-    return Collections.emptyList();
   }
 
-  @Override
+  @ManagedOperation
   public void sendMessage(String message) {
     Message m = new Message(OP.NOTICE);
     m.data.put("notice", message);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -17,10 +17,13 @@
 package org.apache.zeppelin.socket;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URISyntaxException;
@@ -1877,75 +1880,43 @@ public class NotebookServer extends WebSocketServlet
    * Extract running paragraphs info grouped by running interpreters.
    */
   @ManagedOperation
-  public Map<String, Object> getRunningInterpretersParagraphInfo() {
-    Map<String, Object> runningInterpretersWithParagraphInfo = new HashMap<>();
-    notebook().getAllNotes().stream()
+  public List<Map<String, String>> getRunningInterpretersParagraphInfo() {
+    return notebook().getAllNotes().stream()
         .map(Note::getParagraphs)
         .flatMap(Collection::stream)
         .filter(Paragraph::isRunning)
-        .forEach(p -> addBindedInterpreterInfo(runningInterpretersWithParagraphInfo, p));
-    return runningInterpretersWithParagraphInfo;
+        .map(this::addBindedInterpreterInfo)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
   }
 
   /**
    * Update running interpreter info with paragraph data.
    */
-  private void addBindedInterpreterInfo(
-      Map<String, Object> runningInterpretersWithParagraphInfo, Paragraph paragraph) {
-    List<Map<String, String>> runningInterpreters = notebook()
-        .getInterpreterSettingManager()
-        .getRunningInterpreters();
-
-    for (Map<String, String> runningInterpreterInfo : runningInterpreters) {
-      RemoteInterpreterProcess process = null;
-      try {
-        process = ((ManagedInterpreterGroup) paragraph.getBindedInterpreter()
-            .getInterpreterGroup()).getInterpreterProcess();
-      } catch (InterpreterNotFoundException e) {
-        LOG.error("Failed to get binded interpreter to paragraph {}", paragraph, e);
-      }
-      if (process != null
-          && process.getPort() == Integer.valueOf(runningInterpreterInfo.get("port"))
-          && process.getHost().equals(runningInterpreterInfo.get("host"))) {
-
-        Map<String, Object> interpreterInfoBeforeUpdate =
-            (Map<String, Object>) runningInterpretersWithParagraphInfo
-                .get(runningInterpreterInfo.get("name"));
-        if (interpreterInfoBeforeUpdate == null) {
-          // create interpreter info
-          interpreterInfoBeforeUpdate = new HashMap<>();
-          interpreterInfoBeforeUpdate.put("group", runningInterpreterInfo.get("group"));
-          interpreterInfoBeforeUpdate.put("port", runningInterpreterInfo.get("port"));
-          interpreterInfoBeforeUpdate.put("host", runningInterpreterInfo.get("host"));
-
-          // set running interpreter paragraphs
-          List<Map<String, String>> paragraphsInfo = new ArrayList<>();
-          interpreterInfoBeforeUpdate.put("paragraphs", paragraphsInfo);
-        }
-        // update interpreter info
-        List<Map<String, String>> paragraphsInfoBeforeUpdate =
-            (List<Map<String, String>>) interpreterInfoBeforeUpdate.get("paragraphs");
-        addParagraphInfo(paragraphsInfoBeforeUpdate, paragraph);
-
-        runningInterpretersWithParagraphInfo
-            .put(runningInterpreterInfo.get("name"), interpreterInfoBeforeUpdate);
-      }
+  private List<Map<String, String>> addBindedInterpreterInfo(Paragraph paragraph) {
+    try {
+      final RemoteInterpreterProcess process = ((ManagedInterpreterGroup) paragraph
+          .getBindedInterpreter().getInterpreterGroup()).getInterpreterProcess();
+      return notebook().getInterpreterSettingManager().getRunningInterpretersInfo().stream()
+          // find interpreter with same port and host
+          .filter(interpreterInfo ->
+              Integer.valueOf(interpreterInfo.get("port")) == process.getPort()
+              && interpreterInfo.get("host").equals(process.getHost()))
+          .map(interpreterInfo -> ImmutableMap.<String, String>builder()
+              //add all info about interpreter
+              .putAll(interpreterInfo)
+              // add paragraph info
+              .put("interpreterText", paragraph.getIntpText())
+              .put("noteName", paragraph.getNote().getName())
+              .put("noteId", paragraph.getNote().getId())
+              .put("id", paragraph.getId())
+              .put("user", paragraph.getUser())
+              .build())
+          .collect(Collectors.toList());
+    } catch (InterpreterNotFoundException e) {
+      LOG.error("Failed to get binded interpreter for paragraph {}", paragraph, e);
     }
-  }
-
-  /**
-   * Add paragraph info to interpreter paragraph info list.
-   */
-  private void addParagraphInfo(List<Map<String, String>> paragraphsInfoBeforeUpdate,
-      Paragraph paragraph) {
-    Note parentNote = paragraph.getNote();
-    Map<String, String> newParagraphInfo = new HashMap<>();
-    newParagraphInfo.put("interpreterText", paragraph.getIntpText());
-    newParagraphInfo.put("noteName", parentNote.getName());
-    newParagraphInfo.put("noteId", parentNote.getId());
-    newParagraphInfo.put("id", paragraph.getId());
-    newParagraphInfo.put("user", paragraph.getUser());
-    paragraphsInfoBeforeUpdate.add(newParagraphInfo);
+    return Collections.emptyList();
   }
 
   @Override

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -446,7 +446,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
     interpreterInfo.put("port", "1111");
     fakeRunningInterpreterList.add(interpreterInfo);
 
-    when(intpSettingManager.getRunningInterpreters()).thenReturn(fakeRunningInterpreterList);
+    when(intpSettingManager.getRunningInterpretersInfo()).thenReturn(fakeRunningInterpreterList);
 
     final Note note = ZeppelinServer.notebook.createNote("testNote", anonymous);
     final Paragraph fakeParagraph = spy(new Paragraph(note, mock(ParagraphJobListener.class)));
@@ -464,17 +464,19 @@ public class NotebookServerTest extends AbstractTestRestApi {
     when(bindedInterpreter.getInterpreterGroup()).thenReturn(fakeMIG);
     when(fakeParagraph.getBindedInterpreter()).thenReturn(bindedInterpreter);
     when(fakeParagraph.isRunning()).thenReturn(true);
+    when(fakeParagraph.getUser()).thenReturn(String.valueOf(anonymous));
+    when(fakeParagraph.getIntpText()).thenReturn("fake");
 
-    Map<String, Object> result = notebookServer.getRunningInterpretersParagraphInfo();
+    List<Map<String, String>> result = notebookServer.getRunningInterpretersParagraphInfo();
     LOG.info("Running interpreters paragraph info is {}", result);
-    Map<String, Object> resultInterpreterInfo = (Map<String, Object>) result.get("fake");
+
+    assertTrue(!result.isEmpty());
+    assertEquals(1, result.size());
+    Map<String, String> resultInterpreterInfo = result.get(0);
     assertEquals("1111", resultInterpreterInfo.get("port"));
     assertEquals("1.1.1.1", resultInterpreterInfo.get("host"));
-
-    Map<String, String> paragraphInfo =
-        ((List<Map<String, String>>) resultInterpreterInfo.get("paragraphs")).get(0);
-    assertEquals(fakeParagraph.getNote().getName(), paragraphInfo.get("noteName"));
-    assertEquals(fakeParagraph.getUser(), paragraphInfo.get("user"));
+    assertEquals(fakeParagraph.getNote().getName(), resultInterpreterInfo.get("noteName"));
+    assertEquals(fakeParagraph.getUser(), resultInterpreterInfo.get("user"));
 
     // clean
     ZeppelinServer.notebook.removeNote(note.getId(), anonymous);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -25,7 +25,9 @@ import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.ArrayUtils;
@@ -79,6 +81,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -872,21 +875,18 @@ public class InterpreterSettingManager implements NoteEventListener {
   }
 
   @ManagedAttribute
-  public List<Map<String, String>> getRunningInterpreters() {
-    List<Map<String, String>> runningInterpreters = new ArrayList<>();
-    for (Map.Entry<String, InterpreterSetting> entry : interpreterSettings.entrySet()) {
-      for (ManagedInterpreterGroup mig : entry.getValue().getAllInterpreterGroups()) {
-        if (mig.getRemoteInterpreterProcess() != null) {
-          Map<String, String> interpreterInfo = new HashMap<>();
-          interpreterInfo.put("name", mig.getId());
-          interpreterInfo.put("group", mig.getInterpreterSetting().getGroup());
-          interpreterInfo.put("host", mig.getInterpreterProcess().getHost());
-          interpreterInfo.put("port", String.valueOf(mig.getInterpreterProcess().getPort()));
-          runningInterpreters.add(interpreterInfo);
-        }
-      }
-    }
-    return runningInterpreters;
+  public List<Map<String, String>> getRunningInterpretersInfo() {
+    return interpreterSettings.values().stream()
+        .map(InterpreterSetting::getAllInterpreterGroups)
+        .flatMap(Collection::stream)
+        .filter(mig -> mig.getInterpreterProcess() != null)
+        .map(mig -> ImmutableMap.<String, String>builder()
+            .put("name", mig.getId())
+            .put("group", mig.getInterpreterSetting().getGroup())
+            .put("host", mig.getInterpreterProcess().getHost())
+            .put("port", String.valueOf(mig.getInterpreterProcess().getPort()))
+            .build())
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -872,12 +872,17 @@ public class InterpreterSettingManager implements NoteEventListener {
   }
 
   @ManagedAttribute
-  public Set<String> getRunningInterpreters() {
-    Set<String> runningInterpreters = Sets.newHashSet();
+  public List<Map<String, String>> getRunningInterpreters() {
+    List<Map<String, String>> runningInterpreters = new ArrayList<>();
     for (Map.Entry<String, InterpreterSetting> entry : interpreterSettings.entrySet()) {
       for (ManagedInterpreterGroup mig : entry.getValue().getAllInterpreterGroups()) {
-        if (null != mig.getRemoteInterpreterProcess()) {
-          runningInterpreters.add(entry.getKey());
+        if (mig.getRemoteInterpreterProcess() != null) {
+          Map<String, String> interpreterInfo = new HashMap<>();
+          interpreterInfo.put("name", mig.getId());
+          interpreterInfo.put("group", mig.getInterpreterSetting().getGroup());
+          interpreterInfo.put("host", mig.getInterpreterProcess().getHost());
+          interpreterInfo.put("port", String.valueOf(mig.getInterpreterProcess().getPort()));
+          runningInterpreters.add(interpreterInfo);
         }
       }
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -81,10 +81,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 
 /**
@@ -874,18 +872,22 @@ public class InterpreterSettingManager implements NoteEventListener {
     }
   }
 
+  public Map<String, String> extractProcessInfo(ManagedInterpreterGroup mig) {
+    HashMap<String, String> info = new HashMap<>();
+    info.put("name", mig.getId());
+    info.put("group", mig.getInterpreterSetting().getGroup());
+    info.put("host", mig.getInterpreterProcess().getHost());
+    info.put("port", String.valueOf(mig.getInterpreterProcess().getPort()));
+    return info;
+  }
+
   @ManagedAttribute
   public List<Map<String, String>> getRunningInterpretersInfo() {
     return interpreterSettings.values().stream()
         .map(InterpreterSetting::getAllInterpreterGroups)
         .flatMap(Collection::stream)
         .filter(mig -> mig.getInterpreterProcess() != null)
-        .map(mig -> ImmutableMap.<String, String>builder()
-            .put("name", mig.getId())
-            .put("group", mig.getInterpreterSetting().getGroup())
-            .put("host", mig.getInterpreterProcess().getHost())
-            .put("port", String.valueOf(mig.getInterpreterProcess().getPort()))
-            .build())
+        .map(this::extractProcessInfo)
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
### What is this PR for?
It would be nice if we could get PID of running interpreter, and info about paragraph that running under that interpreter, using API and JMX.

Using this feature it will be easy to check CPU and memory load, etc.

This PR adds:
* API method to get info about running interpreters (/api/interpreter/running);
* API method to get info about running paragraphs grouped by interpreters (/api/notebook/running/jobs);
* Few JMX methods which do the same as API;
* Documentation for mentioned methods.

[Here](https://gist.github.com/egorklimov/3c6d00b2afa49c26474192c23687beb3) is the template for simple running paragraphs analysis using API.

### What type of PR is it?
Feature

### What is the Jira issue?
* ZP-91
* [ZEPPELIN-3671](https://issues.apache.org/jira/browse/ZEPPELIN-3671)

### How should this be tested?
* CI pass.
* You may use [template](https://gist.github.com/egorklimov/3c6d00b2afa49c26474192c23687beb3) mentioned above.

### Screenshots
* REST API
![zp-91](https://user-images.githubusercontent.com/6136993/50045157-45a8c800-009f-11e9-901d-d253054ca405.gif)
* JMX (viewed in `jconsole`)
  * Basic info ![jmx_example1](https://user-images.githubusercontent.com/6136993/50548846-99510f00-0c64-11e9-8305-f41aeeb6524c.png)
  * With paragraph info ![jmx_example2](https://user-images.githubusercontent.com/6136993/50548847-99e9a580-0c64-11e9-8564-c92eda149fda.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, API info updated
