### PR TITLE
[ZP-115] JDBC interpreter execution fails with NoClassDefFoundError

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -235,6 +235,7 @@
     <hadoop.common.version>2.7.2</hadoop.common.version>
     <h2.version>1.4.190</h2.version>
     <commons.dbcp2.version>2.0.1</commons.dbcp2.version>
+    <commons.lang.version>2.5</commons.lang.version>
 
     <!--test library versions-->
     <mockrunner.jdbc.version>1.0.8</mockrunner.jdbc.version>
@@ -259,6 +260,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-dbcp2</artifactId>
       <version>${commons.dbcp2.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>${commons.lang.version}</version>
     </dependency>
 
     <dependency>

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -19,6 +19,7 @@ import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
 import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
 
+import java.util.Collections;
 import org.apache.commons.dbcp2.ConnectionFactory;
 import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
 import org.apache.commons.dbcp2.PoolableConnectionFactory;
@@ -867,6 +868,11 @@ public class JDBCInterpreter extends KerberosInterpreter {
   @Override
   public List<InterpreterCompletion> completion(String buf, int cursor,
       InterpreterContext interpreterContext) throws InterpreterException {
+    if (interpreterContext == null || interpreterContext.getAuthenticationInfo() == null) {
+      // AuthenticationInfo could be null if completion called before paragraph execution
+      return Collections.emptyList();
+    }
+
     List<InterpreterCompletion> candidates = new ArrayList<>();
     String propertyKey = getPropertyKey(interpreterContext);
     String sqlCompleterKey =
@@ -875,11 +881,9 @@ public class JDBCInterpreter extends KerberosInterpreter {
 
     Connection connection = null;
     try {
-      if (interpreterContext != null) {
-        connection = getConnection(propertyKey, interpreterContext);
-      }
+      connection = getConnection(propertyKey, interpreterContext);
     } catch (ClassNotFoundException | SQLException | IOException e) {
-      logger.warn("SQLCompleter will created without use connection");
+      logger.warn("SQLCompleter will created without use connection", e);
     }
 
     sqlCompleter = createOrUpdateSqlCompleter(sqlCompleter, connection, propertyKey, buf, cursor);


### PR DESCRIPTION
### What is this PR for?
* **Bug**:
  * Interpreter doesn't work, execution finished with error:
  ```
  ERROR [2019-01-26 17:38:22,839] ({ParallelScheduler-Worker-1} Job.java[run]:174) - Job failed
  java.lang.NoClassDefFoundError: org/apache/commons/lang/StringUtils
  ```
  * If you try to get completion you will get error message: `Fail to get completion, cause: org.apache.thrift.transport.TTransportException`
  * Example:
   ![jdbc-err](https://user-images.githubusercontent.com/6136993/51800468-1a89ca80-2240-11e9-8096-aa34073ff111.gif)
* **Fix**:
  ![jdbc-fix](https://user-images.githubusercontent.com/6136993/51800478-4016d400-2240-11e9-9a90-933d53a0872e.gif)

### What type of PR is it?
* Bug Fix

### What is the Jira issue?
* ZP-115
* ZP-3970

### How should this be tested?
* CI pass
* Manually tested, screencast is attached

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
