### PR TITLE
[ZP-57] UI: Исправить отображение имени ноутбука при наведении курсора

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -448,7 +448,7 @@
 /*Bootstrap uib-tooltip: max-width = 200px
   because of this the string can come out */
 .tooltip-inner {
-  max-width: none !important;
+  max-width: 200px !important;
 }
 
 .select-mode-background {


### PR DESCRIPTION
### What is this PR for?
Сейчас при наведении курсора на имя ноутбука на его странице (/#/notebook/noteId) подсказка с полным названием может выйти за окно.

![error](https://user-images.githubusercontent.com/6136993/52311801-526bdd00-29b9-11e9-8fe4-40860f1beebc.png)

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
*  ZP-57

### How should this be tested?
* CI pass

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
